### PR TITLE
get real MAC address in Android 6+

### DIFF
--- a/library/src/main/java/github/nisrulz/easydeviceinfo/EasyNetworkMod.java
+++ b/library/src/main/java/github/nisrulz/easydeviceinfo/EasyNetworkMod.java
@@ -230,6 +230,45 @@ public class EasyNetworkMod {
    * @return the wifi mac
    */
   @SuppressWarnings("MissingPermission") public String getWifiMAC() {
+    
+     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            String realMac = "02:00:00:00:00:00";
+
+            Enumeration<NetworkInterface> interfaces = null;
+            try {
+                interfaces = NetworkInterface.getNetworkInterfaces();
+            } catch (SocketException e) {
+                e.printStackTrace();
+            }
+            while (interfaces != null && interfaces.hasMoreElements()) {
+                NetworkInterface iF = interfaces.nextElement();
+
+                byte[] addr = new byte[0];
+                try {
+                    addr = iF.getHardwareAddress();
+                } catch (SocketException e) {
+                    e.printStackTrace();
+                }
+                if (addr == null || addr.length == 0) {
+                    continue;
+                }
+
+                StringBuilder buf = new StringBuilder();
+                for (byte b : addr) {
+                    buf.append(String.format("%02X:", b));
+                }
+                if (buf.length() > 0) {
+                    buf.deleteCharAt(buf.length() - 1);
+                }
+                String mac = buf.toString();
+                if (iF.getName().equals("wlan0")) {
+                    realMac = mac;
+                }
+               
+            }
+            return realMac;
+        }
+    
     String result = null;
     if (context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
         == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
[Official document](https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html?hl=zh-cn#behavior-hardware-id) ： `https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html?hl=zh-cn#behavior-hardware-id`

`Android 6+` cann't get real MAC address by call `wm.getConnectionInfo().getMacAddress();`